### PR TITLE
Merge topcyclebug to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OBJECTS := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 RM = rm -f
 
 CC = gcc
-CFLAGS = -std=c99 -pthread -Wall $(INCLUDEFLAG) $(DEPFLAGS)
+CFLAGS = -pthread -Wall $(INCLUDEFLAG) $(DEPFLAGS)
 CFLAGS += -Wextra -Wwrite-strings -Wno-parentheses -Winline
 CFLAGS += -Wpedantic -Warray-bounds
 DEBUGFLAGS = -g -O0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Fast, efficient C implementation of Algorithm-B for the traffic assignment probl
 
 As of 12/26/19, this iteration now includes "batching" for very large OD-matrices.
 
+This code has been updated as of 4/25/20 with various patches and bug fixes.
+
 ## Getting Started
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. There are two main options: normal and parallel.

--- a/obj/.gitignore
+++ b/obj/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/src/bush.c
+++ b/src/bush.c
@@ -109,10 +109,13 @@ void AlgorithmB(network_type *network, algorithmBParameters_type *parameters) {
             clock_gettime(CLOCK_MONOTONIC_RAW, &tock);
             elapsedTime += (double)((1000000000 * (tock.tv_sec - tick.tv_sec) + tock.tv_nsec - tick.tv_nsec)) * 1.0/1000000000; /* Exclude gap calculations from run time */
             stopTime = clock();
+#if NCTCOG_ENABLED
             displayMessage(FULL_NOTIFICATIONS, "Calculating batch relative gap...\n");
-
+#endif
             batchGap = bushRelativeGap(network, bushes, parameters);
+#if NCTCOG_ENABLED
             displayMessage(FULL_NOTIFICATIONS, "Calculated batch relative gap...\n");
+#endif
             gap += batchGap;
             if (parameters->includeGapTime == FALSE) stopTime = clock(); 
             if (parameters->calculateBeckmann == TRUE) {

--- a/src/bush.c
+++ b/src/bush.c
@@ -926,20 +926,20 @@ void updateBushB(int origin, network_type *network, bushes_type *bushes,
     }
    
     /* If strict criterion fails, try a looser one */
-    if (newArcs == 0) {
-        for (ij = 0; ij < network->numArcs; ij++) {
-            i = network->arcs[ij].tail;
-            j = network->arcs[ij].head;
-            if (bushes->LPcost[i]==-INFINITY && bushes->LPcost[j]>-INFINITY)
-                continue; /* No path to extend */
-            if (bushes->flow[ij] == 0 && bushes->LPcost[i] < bushes->LPcost[j]
-                && (network->arcs[ij].tail == origin2node(network, origin)
-                    || network->arcs[ij].tail >= network->firstThroughNode))
-            {
-                bushes->flow[ij] = NEW_LINK;
-            }
-        }
-    }      
+    // if (newArcs == 0) {
+    //     for (ij = 0; ij < network->numArcs; ij++) {
+    //         i = network->arcs[ij].tail;
+    //         j = network->arcs[ij].head;
+    //         if (bushes->LPcost[i]==-INFINITY && bushes->LPcost[j]>-INFINITY)
+    //             continue; /* No path to extend */
+    //         if (bushes->flow[ij] == 0 && bushes->LPcost[i] < bushes->LPcost[j]
+    //             && (network->arcs[ij].tail == origin2node(network, origin)
+    //                 || network->arcs[ij].tail >= network->firstThroughNode))
+    //         {
+    //             bushes->flow[ij] = NEW_LINK;
+    //         }
+    //     }
+    // }      
 
    /* Finally update bush data structures: delete/add merges, find a new
     * topological order, rectify approach proportions */

--- a/src/parallel_bush.c
+++ b/src/parallel_bush.c
@@ -119,21 +119,21 @@ void updateBushB_par(int origin, network_type *network, bushes_type *bushes,
         }
     }
 
-    /* If strict criterion fails, try a looser one */
-    if (newArcs == 0) {
-        for (ij = 0; ij < network->numArcs; ij++) {
-            i = network->arcs[ij].tail;
-            j = network->arcs[ij].head;
-            if (bushes->LPcost_par[origin][i]==-INFINITY && bushes->LPcost_par[origin][j]>-INFINITY)
-                continue; /* No path to extend */
-            if (bushes->flow_par[origin][ij] == 0 && bushes->LPcost_par[origin][i] < bushes->LPcost_par[origin][j]
-                && (network->arcs[ij].tail == origin2node(network, origin)
-                    || network->arcs[ij].tail >= network->firstThroughNode))
-            {
-                bushes->flow_par[origin][ij] = NEW_LINK;
-            }
-        }
-    }
+//    /* If strict criterion fails, try a looser one */
+//    if (newArcs == 0) {
+//        for (ij = 0; ij < network->numArcs; ij++) {
+//            i = network->arcs[ij].tail;
+//            j = network->arcs[ij].head;
+//            if (bushes->LPcost_par[origin][i]==-INFINITY && bushes->LPcost_par[origin][j]>-INFINITY)
+//                continue; /* No path to extend */
+//            if (bushes->flow_par[origin][ij] == 0 && bushes->LPcost_par[origin][i] < bushes->LPcost_par[origin][j]
+//                && (network->arcs[ij].tail == origin2node(network, origin)
+//                    || network->arcs[ij].tail >= network->firstThroughNode))
+//            {
+//                bushes->flow_par[origin][ij] = NEW_LINK;
+//            }
+//        }
+//    }
 
     /* Finally update bush data structures: delete/add merges, find a new
      * topological order, rectify approach proportions */


### PR DESCRIPTION
This branch made modifications to the original source code by commenting out a potential optimization made in bush.c and parallel_bush.c:
```
    if (newArcs == 0) {
        for (ij = 0; ij < network->numArcs; ij++) {
            i = network->arcs[ij].tail;
            j = network->arcs[ij].head;
            if (bushes->LPcost[i]==-INFINITY && bushes->LPcost[j]>-INFINITY)
                continue; /* No path to extend */
            if (bushes->flow[ij] == 0 && bushes->LPcost[i] < bushes->LPcost[j]
                && (network->arcs[ij].tail == origin2node(network, origin)
                    || network->arcs[ij].tail >= network->firstThroughNode))
            {
                bushes->flow[ij] = NEW_LINK;
            }
        }
    }      
```
There is no exact reason for whether this optimization was necessary, but we observed proper correctness guarantees after this section was commented out. Please review theses changes and merge accordingly. 