### PR TITLE
Remove artificial links from flows.txt

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -820,6 +820,7 @@ void writeNetworkFlows(network_type *network, char *outputFileName) {
     int ij;
 
     for (ij = 0; ij < network->numArcs; ij++) {
+        if (network->arcs[ij].capacity == ARTIFICIAL) continue;
         fprintf(outFile, "(%d,%d) %f %f\n", network->arcs[ij].tail + 1,
                                             network->arcs[ij].head + 1,
                                             network->arcs[ij].flow,


### PR DESCRIPTION
This quick fix removes artificial links from the flows.txt output file (solves issue #7 ). The only potential issue I see here is that the artificial link capacity is set to 99999. We may need to up this up in case we have a conflict for a large network, though I'm not sure.