### PR TITLE
Addressing the creation of Cyclic Bushes created in UpdateBushB

### DIFF
--- a/include/bush.h
+++ b/include/bush.h
@@ -41,6 +41,12 @@
 
 #define NEW_LINK -1
 //#define PARALLELISM 1
+typedef enum scan_type {
+    LONGEST_BUSH_PATH,
+    LONGEST_USED_PATH,
+    LONGEST_USED_OR_SP,
+    NO_LONGEST_PATH
+} scan_type;
 
 /*
  * merge_type: Extra data for merge nodes
@@ -244,6 +250,7 @@ typedef struct algorithmBParameters_type{
    bool     warmStart;
    bool     calculateBeckmann;
    queueDiscipline SPQueueDiscipline;
+   scan_type updateBushScanType;
    void     (*createInitialBush)(int, network_type *, bushes_type *,
                                  struct algorithmBParameters_type *);
    void     (*topologicalOrder)(int, network_type *, bushes_type *,
@@ -261,13 +268,6 @@ typedef struct algorithmBParameters_type{
    char     matrixStem[STRING_SIZE-20];
    char     flowsFile[STRING_SIZE];
 } algorithmBParameters_type;
-
-typedef enum scan_type {
-    LONGEST_BUSH_PATH,
-    LONGEST_USED_PATH,
-    LONGEST_USED_OR_SP,
-    NO_LONGEST_PATH
-} scan_type;
 
 /* Master routine and parameters */
 void AlgorithmB(network_type *network, algorithmBParameters_type *parameters);

--- a/src/bush.c
+++ b/src/bush.c
@@ -196,6 +196,7 @@ algorithmBParameters_type initializeAlgorithmBParameters() {
     
     parameters.includeGapTime = TRUE;
 
+    parameters.updateBushScanType = LONGEST_USED_OR_SP;
     parameters.createInitialBush = &initialBushShortestPath;
     parameters.topologicalOrder = &genericTopologicalOrder;
     parameters.linkShiftB = &exactCostUpdate;
@@ -889,7 +890,7 @@ void updateBushB(int origin, network_type *network, bushes_type *bushes,
    
     /* First update labels... ignoring longest unused paths since those will be
      * removed in the next step. */
-    scanBushes(origin, network, bushes, parameters, LONGEST_USED_OR_SP);
+    scanBushes(origin, network, bushes, parameters, parameters->updateBushScanType);
     calculateBushFlows(origin, network, bushes);
   
     /* Make a first pass... */
@@ -926,7 +927,7 @@ void updateBushB(int origin, network_type *network, bushes_type *bushes,
     }
    
     /* If strict criterion fails, try a looser one */
-     if (newArcs == 0) {
+     if (newArcs == 0 && parameters->updateBushScanType == LONGEST_BUSH_PATH) {
          for (ij = 0; ij < network->numArcs; ij++) {
              i = network->arcs[ij].tail;
              j = network->arcs[ij].head;

--- a/src/bush.c
+++ b/src/bush.c
@@ -926,20 +926,20 @@ void updateBushB(int origin, network_type *network, bushes_type *bushes,
     }
    
     /* If strict criterion fails, try a looser one */
-    // if (newArcs == 0) {
-    //     for (ij = 0; ij < network->numArcs; ij++) {
-    //         i = network->arcs[ij].tail;
-    //         j = network->arcs[ij].head;
-    //         if (bushes->LPcost[i]==-INFINITY && bushes->LPcost[j]>-INFINITY)
-    //             continue; /* No path to extend */
-    //         if (bushes->flow[ij] == 0 && bushes->LPcost[i] < bushes->LPcost[j]
-    //             && (network->arcs[ij].tail == origin2node(network, origin)
-    //                 || network->arcs[ij].tail >= network->firstThroughNode))
-    //         {
-    //             bushes->flow[ij] = NEW_LINK;
-    //         }
-    //     }
-    // }      
+     if (newArcs == 0) {
+         for (ij = 0; ij < network->numArcs; ij++) {
+             i = network->arcs[ij].tail;
+             j = network->arcs[ij].head;
+             if (bushes->LPcost[i]==-INFINITY && bushes->LPcost[j]>-INFINITY)
+                 continue; /* No path to extend */
+             if (bushes->flow[ij] == 0 && bushes->LPcost[i] < bushes->LPcost[j]
+                 && (network->arcs[ij].tail == origin2node(network, origin)
+                     || network->arcs[ij].tail >= network->firstThroughNode))
+             {
+                 bushes->flow[ij] = NEW_LINK;
+             }
+         }
+     }
 
    /* Finally update bush data structures: delete/add merges, find a new
     * topological order, rectify approach proportions */
@@ -985,6 +985,7 @@ void reconstructMerges(int origin, network_type *network, bushes_type *bushes){
                        "incoming contributing links", i, origin);
         if (numApproaches == 1) { /* No merge */
             bushes->pred[origin][i] = lastApproach;
+            if (bushes->flow[lastApproach] == NEW_LINK) bushes->flow[lastApproach] = 0;
         } else { /* Must create a merge */
             merge = createMerge(numApproaches);
             arc = 0;

--- a/src/parallel_bush.c
+++ b/src/parallel_bush.c
@@ -119,21 +119,21 @@ void updateBushB_par(int origin, network_type *network, bushes_type *bushes,
         }
     }
 
-//    /* If strict criterion fails, try a looser one */
-//    if (newArcs == 0) {
-//        for (ij = 0; ij < network->numArcs; ij++) {
-//            i = network->arcs[ij].tail;
-//            j = network->arcs[ij].head;
-//            if (bushes->LPcost_par[origin][i]==-INFINITY && bushes->LPcost_par[origin][j]>-INFINITY)
-//                continue; /* No path to extend */
-//            if (bushes->flow_par[origin][ij] == 0 && bushes->LPcost_par[origin][i] < bushes->LPcost_par[origin][j]
-//                && (network->arcs[ij].tail == origin2node(network, origin)
-//                    || network->arcs[ij].tail >= network->firstThroughNode))
-//            {
-//                bushes->flow_par[origin][ij] = NEW_LINK;
-//            }
-//        }
-//    }
+    /* If strict criterion fails, try a looser one */
+    if (newArcs == 0) {
+        for (ij = 0; ij < network->numArcs; ij++) {
+            i = network->arcs[ij].tail;
+            j = network->arcs[ij].head;
+            if (bushes->LPcost_par[origin][i]==-INFINITY && bushes->LPcost_par[origin][j]>-INFINITY)
+                continue; /* No path to extend */
+            if (bushes->flow_par[origin][ij] == 0 && bushes->LPcost_par[origin][i] < bushes->LPcost_par[origin][j]
+                && (network->arcs[ij].tail == origin2node(network, origin)
+                    || network->arcs[ij].tail >= network->firstThroughNode))
+            {
+                bushes->flow_par[origin][ij] = NEW_LINK;
+            }
+        }
+    }
 
     /* Finally update bush data structures: delete/add merges, find a new
      * topological order, rectify approach proportions */
@@ -180,6 +180,7 @@ void reconstructMerges_par(int origin, network_type *network, bushes_type *bushe
                        "incoming contributing links", i, origin);
         if (numApproaches == 1) { /* No merge */
             bushes->pred[origin][i] = lastApproach;
+            if (bushes->flow_par[origin][lastApproach] == NEW_LINK) bushes->flow_par[origin][lastApproach] = 0;
         } else { /* Must create a merge */
             merge = createMerge(numApproaches);
             arc = 0;

--- a/src/parallel_bush.c
+++ b/src/parallel_bush.c
@@ -83,7 +83,7 @@ void updateBushB_par(int origin, network_type *network, bushes_type *bushes,
 
     /* First update labels... ignoring longest unused paths since those will be
      * removed in the next step. */
-    scanBushes_par(origin, network, bushes, parameters, LONGEST_USED_OR_SP);
+    scanBushes_par(origin, network, bushes, parameters, parameters->updateBushScanType);
     calculateBushFlows_par(origin, network, bushes);
 
     /* Make a first pass... */
@@ -120,7 +120,7 @@ void updateBushB_par(int origin, network_type *network, bushes_type *bushes,
     }
 
     /* If strict criterion fails, try a looser one */
-    if (newArcs == 0) {
+    if (newArcs == 0 && parameters->updateBushScanType == LONGEST_BUSH_PATH) {
         for (ij = 0; ij < network->numArcs; ij++) {
             i = network->arcs[ij].tail;
             j = network->arcs[ij].head;


### PR DESCRIPTION
We had two bugs earlier that were creating cycles in bushes:

- The first one was when new links added as SP links to maintain connectivity were not being set to have 0 flow during reconstructMerges. As a result, other links up and down the bush were being marked as new links. To fix, we added a line to reconstruct merges to set the flow on the link to 0 when there was one approach to a merge.

- The second bug was the old bug that @cangokalp had found with the loose condition for adding links to bushes was creating a cycle. The reason for this was that we were using longest used path instead of outright longest bush path to determine wether a link should be added. To fix, we put a check for the type of longest path were labels calculated for updateBushB

